### PR TITLE
Changes gameStartText to refer to time when setup ends.

### DIFF
--- a/timer.html
+++ b/timer.html
@@ -119,7 +119,7 @@
           var gameEnd = setupEnd + (numRounds * roundDuration); // scheduled end
           var gameDuration = gameEnd - setupEnd;
           var startDate = new Date(gameStarttime * 1000);
-          var gameStartText = startDate.toLocaleTimeString();
+          var gameStartText = setupEnd.toLocaleTimeString();
           var numText = gameNumber == 0 ? "State" : gameNumber;
 
           if ((gameEndtime >= gameStarttime && gameEndtime <= now) ||


### PR DESCRIPTION
This will result in a future timestamp during setup, with the text "Game starts at", reflecting the time actual gameplay is due to start.  This is also the more correct timestamp to use during gameplay for "Game started at" as well.