### PR TITLE
Present the 'dw' territory option before 'wd'.

### DIFF
--- a/templates/judge.html
+++ b/templates/judge.html
@@ -361,18 +361,18 @@
                 <div class="col-xs-6">
                   <div class="form-group text-center one-line-radio radio-required">
                     <label class="radio-inline"
-                        title="Red defending Wean. Yellow defending Doherty.">
-                      <input type="radio" name="territory" value="wd">
-                      <span class="text-danger">WeH</span>
-                      /
-                      <span class="text-warning">DH</span>
-                    </label>
-                    <label class="radio-inline"
                         title="Red defending Doherty. Yellow defending Wean.">
                       <input type="radio" name="territory" value="dw">
                       <span class="text-danger">DH</span>
                       /
                       <span class="text-warning">WeH</span>
+                    </label>
+                    <label class="radio-inline"
+                        title="Red defending Wean. Yellow defending Doherty.">
+                      <input type="radio" name="territory" value="wd">
+                      <span class="text-danger">WeH</span>
+                      /
+                      <span class="text-warning">DH</span>
                     </label>
                     <p id="territorySpan" class="judge-value text-center"></p>
                   </div>


### PR DESCRIPTION
Since typically Red defends Doherty and Yellow defends Wean in Game 1, present
this as the first option for the 'territory' field in the Judges' game panel.