### PR TITLE
Rewrite start game script to allow for custom game config

### DIFF
--- a/scripts/start_game.sh
+++ b/scripts/start_game.sh
@@ -9,22 +9,36 @@ source $(dirname "$script_file")/get_password.sh
 
 zero_flags_arg="--zero-flags"
 send_message_arg="--send-message"
+setup_duration_arg="--setup-duration"
+rounds_arg="--rounds"
+round_duration_arg="--round-duration"
+
+DEFAULT_SETUP_DURATION="900"
+DEFAULT_ROUNDS="4"
+DEFAULT_ROUND_DURATION="900"
 
 player_message_template='Red is defending $red. Yellow is defending $yellow.'
 jail_message_template='R=$red Y=$yellow'
 
-if [ "$#" -ne 3 ] && [ "$#" -ne 4 ] && [ "$#" -ne 5 ] && [ "$#" -ne 6 ]
+if [ "$#" -lt 3 ]
 then
-  echo "Usage: $0 num_flags game_num territory [timestamp] [$zero_flags_arg] [$send_message_arg]"
+  echo "Usage: $0 num_flags game_num territory [timestamp] [$zero_flags_arg] [$send_message_arg] [$setup_duration_arg setup_duration] [$rounds_arg rounds] [$round_duration_arg round_duration]"
   echo "       territory is either 'dw' (for red defending Doherty) or 'wd'"
   echo "If $zero_flags_arg is set, flags will be set to '0 0'"
   echo "If $send_message_arg is set, a default initial message will be sent"
   echo "       Message for players: \"$player_message_template\""
   echo "       Message for jails: \"$jail_message_template\""
+  echo "Custom game configuration can be specified; default is:"
+  echo "       $setup_duration_arg $DEFAULT_SETUP_DURATION"
+  echo "       $rounds_arg $DEFAULT_ROUNDS"
+  echo "       $round_duration_arg $DEFAULT_ROUND_DURATION"
   exit 1
 else
   do_zero_flags=false
   do_send_message=false
+  setup_duration="$DEFAULT_SETUP_DURATION"
+  rounds="$DEFAULT_ROUNDS"
+  round_duration="$DEFAULT_ROUND_DURATION"
   num_flags="$1"
   game_num="$2"
   territory="$3"
@@ -50,9 +64,23 @@ else
     if [ "$1" = "$zero_flags_arg" ]
     then
       do_zero_flags=true
+      shift
     elif [ "$1" = "$send_message_arg" ]
     then
       do_send_message=true
+      shift
+    elif [ "$1" = "$setup_duration_arg" ]
+    then
+      setup_duration=$2
+      shift 2
+    elif [ "$1" = "$rounds_arg" ]
+    then
+      rounds=$2
+      shift 2
+    elif [ "$1" = "$round_duration_arg" ]
+    then
+      round_duration=$2
+      shift 2
     else
       if [ "$date" != "" ]
       then
@@ -60,8 +88,8 @@ else
         exit 1
       fi
       date="$1"
+      shift
     fi
-    shift
   done
 
   if [ "$date" = "" ]
@@ -69,9 +97,12 @@ else
     date=$(date +%s)
   fi
 
-  m="$date 900 4 900 $num_flags $game_num $territory"
+  m="$date $setup_duration $rounds $round_duration $num_flags $game_num $territory"
   mosquitto_pub -u ctfwsmaster -P $(cat $password_file) -q 1 -r -t ctfws/game/config -m "$m" &&
   echo "Started game $game_num with $num_flags flags at $date (Red in $red / Yellow in $yellow)" &&
+  echo "    Setup duration: $setup_duration seconds"
+  echo "    Rounds: $rounds rounds"
+  echo "    Round duration: $round_duration seconds"
 
   if [ "$do_zero_flags" = true ]
   then

--- a/templates/timer.html
+++ b/templates/timer.html
@@ -63,12 +63,12 @@
               earlyGameEnd: 0, // Time of game end if ended before schduled
             },
             rounds: {
-              // Number of jailbreaks. Set by the broker but always should be 4.
+              // Number of jailbreaks. Set by the broker but is typically 4.
               total: 4,
-              // Jailbreak length in secs. Also set by broker but always 15 min.
+              // Jailbreak length in secs. Also set by broker but is typically 15 min.
               duration: 15 * 60,
             },
-            // Setup length in secs. Also set by broker but always 15 min.
+            // Setup length in secs. Also set by broker but is typically 15 min.
             setupDuration: 15 * 60,
             stun: {
               start: 0,


### PR DESCRIPTION
Introduces optional parameters `--setup-duration`, `--rounds`, and `--round-duration` while keeping the defaults of 900, 4, and 900, respectively.

This lays the groundwork for addressing #6.